### PR TITLE
Add FlipFlopPredicate module and upgrade Java version

### DIFF
--- a/diffblue-cover/diffblue-flipflop/pom.xml
+++ b/diffblue-cover/diffblue-flipflop/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>epam</groupId>
+        <artifactId>diffblue-cover</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>diffblue-flipflop</artifactId>
+
+    <name>
+        Flip-Flop Predicate
+    </name>
+    <description>
+        Emulates flip-flop logic similar to two-dots flip-flop in Perl or Ruby.
+    </description>
+    <url>
+        https://en.wikipedia.org/wiki/Flip-flop_(programming)
+    </url>
+
+</project>

--- a/diffblue-cover/diffblue-flipflop/src/main/java/diffblue/flipflop/FlipFlopPredicate.java
+++ b/diffblue-cover/diffblue-flipflop/src/main/java/diffblue/flipflop/FlipFlopPredicate.java
@@ -1,0 +1,26 @@
+package diffblue.flipflop;
+
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Emulates flip-flop logic similar to two-dots flip-flop in Perl or Ruby.
+ */
+public final class FlipFlopPredicate<T> implements Predicate<T> {
+    private final Predicate<? super T> startPredicate;
+    private final Predicate<? super T> endPredicate;
+    private boolean state;
+
+    public FlipFlopPredicate(Predicate<? super T> lhs, Predicate<? super T> rhs) {
+        this.startPredicate = requireNonNull(lhs);
+        this.endPredicate = requireNonNull(rhs);
+    }
+
+    @Override
+    public boolean test(final T value) {
+        var result = state || startPredicate.test(value);
+        state = result && !endPredicate.test(value);
+        return result;
+    }
+}

--- a/diffblue-cover/diffblue-flipflop/src/test/java/diffblue/flipflop/FlipFlopPredicateDiffblueTest.java
+++ b/diffblue-cover/diffblue-flipflop/src/test/java/diffblue/flipflop/FlipFlopPredicateDiffblueTest.java
@@ -1,0 +1,172 @@
+package diffblue.flipflop;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class FlipFlopPredicateDiffblueTest {
+    /**
+     * Method under test:
+     * {@link FlipFlopPredicate#FlipFlopPredicate(Predicate, Predicate)}
+     */
+    @Test
+    void testConstructor() {
+        // Arrange
+        Predicate<Object> lhs = mock(Predicate.class);
+        when(lhs.test(Mockito.<Object>any())).thenReturn(true);
+        Predicate<Object> rhs = mock(Predicate.class);
+        when(rhs.test(Mockito.<Object>any())).thenReturn(true);
+
+        // Act
+        FlipFlopPredicate<Object> actualFlipFlopPredicate = new FlipFlopPredicate<>(lhs, rhs);
+        String string = "Value";
+        boolean actualTestResult = actualFlipFlopPredicate.test(string);
+
+        // Assert
+        verify(lhs).test(Mockito.<Object>any());
+        verify(rhs).test(Mockito.<Object>any());
+        assertTrue(actualTestResult);
+    }
+
+    /**
+     * Method under test:
+     * {@link FlipFlopPredicate#FlipFlopPredicate(Predicate, Predicate)}
+     */
+    @Test
+    void testConstructor2() {
+        // Arrange
+        Predicate<Object> lhs = mock(Predicate.class);
+        when(lhs.test(Mockito.<Object>any())).thenReturn(false);
+        Predicate<Object> rhs = mock(Predicate.class);
+        when(rhs.test(Mockito.<Object>any())).thenReturn(true);
+
+        // Act
+        FlipFlopPredicate<Object> actualFlipFlopPredicate = new FlipFlopPredicate<>(lhs, rhs);
+        String string = "Value";
+        boolean actualTestResult = actualFlipFlopPredicate.test(string);
+
+        // Assert
+        verify(lhs).test(Mockito.<Object>any());
+        assertFalse(actualTestResult);
+    }
+
+    /**
+     * Method under test:
+     * {@link FlipFlopPredicate#FlipFlopPredicate(Predicate, Predicate)}
+     */
+    @Test
+    void testConstructor3() {
+        // Arrange
+        Predicate<Object> lhs = mock(Predicate.class);
+        when(lhs.test(Mockito.<Object>any())).thenReturn(true);
+        Predicate<Object> rhs = mock(Predicate.class);
+        when(rhs.test(Mockito.<Object>any())).thenReturn(false);
+
+        // Act
+        FlipFlopPredicate<Object> actualFlipFlopPredicate = new FlipFlopPredicate<>(lhs, rhs);
+        String string = "Value";
+        boolean actualTestResult = actualFlipFlopPredicate.test(string);
+
+        // Assert
+        verify(lhs).test(Mockito.<Object>any());
+        verify(rhs).test(Mockito.<Object>any());
+        assertTrue(actualTestResult);
+    }
+
+    /**
+     * Method under test: {@link FlipFlopPredicate#test(Object)}
+     */
+    @Test
+    void testTest() {
+        // Arrange
+        Predicate<Object> lhs = mock(Predicate.class);
+        when(lhs.test(Mockito.<Object>any())).thenReturn(true);
+        Predicate<Object> rhs = mock(Predicate.class);
+        when(rhs.test(Mockito.<Object>any())).thenReturn(true);
+        FlipFlopPredicate<Object> flipFlopPredicate = new FlipFlopPredicate<>(lhs, rhs);
+        String string = "Value";
+
+        // Act
+        boolean actualTestResult = flipFlopPredicate.test(string);
+
+        // Assert
+        verify(lhs).test(Mockito.<Object>any());
+        verify(rhs).test(Mockito.<Object>any());
+        assertTrue(actualTestResult);
+    }
+
+    /**
+     * Method under test: {@link FlipFlopPredicate#test(Object)}
+     */
+    @Test
+    void testTest2() {
+        // Arrange
+        Predicate<Object> lhs = mock(Predicate.class);
+        when(lhs.test(Mockito.<Object>any())).thenReturn(false);
+        Predicate<Object> rhs = mock(Predicate.class);
+        when(rhs.test(Mockito.<Object>any())).thenReturn(true);
+        FlipFlopPredicate<Object> flipFlopPredicate = new FlipFlopPredicate<>(lhs, rhs);
+        String string = "Value";
+
+        // Act
+        boolean actualTestResult = flipFlopPredicate.test(string);
+
+        // Assert
+        verify(lhs).test(Mockito.<Object>any());
+        assertFalse(actualTestResult);
+    }
+
+    /**
+     * Method under test: {@link FlipFlopPredicate#test(Object)}
+     */
+    @Test
+    void testTest3() {
+        // Arrange
+        Predicate<Object> lhs = mock(Predicate.class);
+        when(lhs.test(Mockito.<Object>any())).thenReturn(true);
+        Predicate<Object> rhs = mock(Predicate.class);
+        when(rhs.test(Mockito.<Object>any())).thenReturn(false);
+        FlipFlopPredicate<Object> flipFlopPredicate = new FlipFlopPredicate<>(lhs, rhs);
+        String string = "Value";
+
+        // Act
+        boolean actualTestResult = flipFlopPredicate.test(string);
+
+        // Assert
+        verify(lhs).test(Mockito.<Object>any());
+        verify(rhs).test(Mockito.<Object>any());
+        assertTrue(actualTestResult);
+    }
+
+    /**
+     * Method under test: {@link FlipFlopPredicate#test(Object)}
+     */
+    @Test
+    void testTest4() {
+        // Arrange
+        Predicate<Object> lhs = mock(Predicate.class);
+        when(lhs.test(Mockito.<Object>any())).thenReturn(true);
+        Predicate<Object> rhs = mock(Predicate.class);
+        when(rhs.test(Mockito.<Object>any())).thenReturn(false);
+
+        FlipFlopPredicate<Object> flipFlopPredicate = new FlipFlopPredicate<>(lhs, rhs);
+        flipFlopPredicate.test(0);
+        String string = "42";
+
+        // Act
+        boolean actualTestResult = flipFlopPredicate.test(string);
+
+        // Assert
+        verify(lhs).test(Mockito.<Object>any());
+        verify(rhs, atLeast(1)).test(Mockito.<Object>any());
+        assertTrue(actualTestResult);
+    }
+}

--- a/diffblue-cover/pom.xml
+++ b/diffblue-cover/pom.xml
@@ -24,13 +24,22 @@
 
     <modules>
         <module>diffblue-roman</module>
+        <module>diffblue-flipflop</module>
     </modules>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Introduced a new module named 'diffblue-flipflop' to the build. This module includes the FlipFlopPredicate class and its test cases which emulate flip-flop logic similar to two-dots flip-flop in Perl or Ruby. Also updated the Java version used in the project to Java 17. Updated the Junit dependency to 'junit-jupiter', and added a new dependency 'mockito-core' for mocking in tests. The new module and dependencies have been added to enhance the project's functionality and testing capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `FlipFlopPredicate` for advanced conditional logic.

- **Tests**
  - Added comprehensive tests for the `FlipFlopPredicate` to ensure reliability and correct behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->