### PR TITLE
Add legal age module with its predicate implementation and tests

### DIFF
--- a/diffblue-cover/diffblue-legal-age/pom.xml
+++ b/diffblue-cover/diffblue-legal-age/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>epam</groupId>
+        <artifactId>diffblue-cover</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>diffblue-legal-age</artifactId>
+
+    <name>
+        Legal Age Predicate
+    </name>
+    <description>
+        Emulates a predicate that checks if a person is of legal age.
+    </description>
+    <url>
+        https://en.wikipedia.org/wiki/Legal_age
+    </url>
+
+</project>

--- a/diffblue-cover/diffblue-legal-age/src/main/java/diffblue/legalage/LegalAgePredicate.java
+++ b/diffblue-cover/diffblue-legal-age/src/main/java/diffblue/legalage/LegalAgePredicate.java
@@ -1,0 +1,14 @@
+package diffblue.legalage;
+
+import java.time.LocalDate;
+import java.util.function.Predicate;
+
+public class LegalAgePredicate implements Predicate<LocalDate> {
+
+    @Override
+    public boolean test(LocalDate birthday) {
+        int yearOfBirth = birthday.getYear();
+        int yearNow = LocalDate.now().getYear();
+        return yearNow - yearOfBirth >= 18;
+    }
+}

--- a/diffblue-cover/diffblue-legal-age/src/test/java/diffblue/legalage/LegalAgePredicateDiffblueTest.java
+++ b/diffblue-cover/diffblue-legal-age/src/test/java/diffblue/legalage/LegalAgePredicateDiffblueTest.java
@@ -1,0 +1,25 @@
+package diffblue.legalage;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+class LegalAgePredicateDiffblueTest {
+    /**
+     * Method under test: {@link LegalAgePredicate#test(LocalDate)}
+     */
+    @Test
+    void testTest() {
+        // Arrange
+        LegalAgePredicate legalAgePredicate = new LegalAgePredicate();
+        LocalDate birthday = LocalDate.now();
+
+        // Act
+        boolean actualTestResult = legalAgePredicate.test(birthday);
+
+        // Assert
+        assertFalse(actualTestResult);
+    }
+}

--- a/diffblue-cover/pom.xml
+++ b/diffblue-cover/pom.xml
@@ -25,6 +25,7 @@
     <modules>
         <module>diffblue-roman</module>
         <module>diffblue-flipflop</module>
+        <module>diffblue-legal-age</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This commit includes the creation of a new module 'diffblue-legal-age' in the main pom.xml file. A new class `LegalAgePredicate`, implementing the Predicate interface, was added to calculate if given birthdate pertains to legal age or not. A new 'pom.xml' file was added for the module and a test class 'LegalAgePredicateDiffblueTest' was added to include tests for the legal age predicate. This new functionality is essential for age verification in several parts of our application's logic.