### PR TITLE
Add RomanToArabicConverter and corresponding tests

### DIFF
--- a/github-copilot/copilot-roman/src/main/java/copilot/roman/RomanToArabicConverter.java
+++ b/github-copilot/copilot-roman/src/main/java/copilot/roman/RomanToArabicConverter.java
@@ -1,0 +1,12 @@
+package copilot.roman;
+
+import java.util.function.ToIntFunction;
+
+
+public final class RomanToArabicConverter implements ToIntFunction<String> {
+
+    @Override
+    public int applyAsInt(String value) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/github-copilot/copilot-roman/src/test/groovy/copilot/roman/RomanToArabicConverterTest.groovy
+++ b/github-copilot/copilot-roman/src/test/groovy/copilot/roman/RomanToArabicConverterTest.groovy
@@ -49,22 +49,4 @@ class RomanToArabicConverterTest extends Specification {
         'MMXXI'     | 2021
         'MMMCMXCIX' | 3999
     }
-
-    @PendingFeature
-    def 'result is undefined for invalid Roman numerals'() {
-        given:
-        def converter = new RomanToArabicConverter()
-
-        when:
-        converter.applyAsInt(invalidRomanNumeral)
-
-        then:
-        notThrown IllegalArgumentException
-
-        where:
-        invalidRomanNumeral << [
-            'IIII', 'VV', 'XXXX', 'LL', 'CCCC', 'DD', 'MMMM',
-            'AB', '478', '#$%', 'MCMXCIIX', 'MCMXCIIX', 'MCMXCIIX'
-        ]
-    }
 }

--- a/github-copilot/copilot-roman/src/test/groovy/copilot/roman/RomanToArabicConverterTest.groovy
+++ b/github-copilot/copilot-roman/src/test/groovy/copilot/roman/RomanToArabicConverterTest.groovy
@@ -1,0 +1,70 @@
+package copilot.roman
+
+import spock.lang.*
+
+@Title('Roman to Arabic converter')
+@Narrative("""
+As a mathematician
+I want to convert roman numerals to arabic numbers
+So that I can do arithmetic with them
+""")
+@Issue('1')
+@See('https://en.wikipedia.org/wiki/Roman_numerals')
+class RomanToArabicConverterTest extends Specification {
+
+    @PendingFeature
+    @Unroll('convert #roman to #arabic')
+    def 'convert roman numeral to arabic number'() {
+        given:
+        def converter = new RomanToArabicConverter()
+
+        expect:
+        converter.applyAsInt(roman) == arabic
+
+        where:
+        roman       | arabic
+        'I'         | 1
+        'II'        | 2
+        'III'       | 3
+        'IV'        | 4
+        'V'         | 5
+        'VI'        | 6
+        'VII'       | 7
+        'VIII'      | 8
+        'IX'        | 9
+        'X'         | 10
+        'XI'        | 11
+        'XL'        | 40
+        'L'         | 50
+        'LX'        | 60
+        'XC'        | 90
+        'C'         | 100
+        'CX'        | 110
+        'CD'        | 400
+        'D'         | 500
+        'DC'        | 600
+        'CM'        | 900
+        'M'         | 1000
+        'MCMXCIX'   | 1999
+        'MMXXI'     | 2021
+        'MMMCMXCIX' | 3999
+    }
+
+    @PendingFeature
+    def 'result is undefined for invalid Roman numerals'() {
+        given:
+        def converter = new RomanToArabicConverter()
+
+        when:
+        converter.applyAsInt(invalidRomanNumeral)
+
+        then:
+        notThrown IllegalArgumentException
+
+        where:
+        invalidRomanNumeral << [
+            'IIII', 'VV', 'XXXX', 'LL', 'CCCC', 'DD', 'MMMM',
+            'AB', '478', '#$%', 'MCMXCIIX', 'MCMXCIIX', 'MCMXCIIX'
+        ]
+    }
+}


### PR DESCRIPTION
Added RomanToArabicConverter class and its corresponding test class. The converter class is set to throw UnsupportedOperationException until it is implemented. The test class tests for the conversion of a wide range of roman numerals to their respective arabic numbers as well as checking that the converter responds appropriately to invalid roman numerals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a placeholder for the Roman to Arabic number conversion feature.

- **Tests**
  - Added new test cases for validating Roman numeral conversion, currently marked as pending.

- **Documentation**
  - Noted that the Roman numeral conversion feature is not implemented yet and will throw an exception if used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->