### PR TITLE
Implement Roman to Arabic number conversion

### DIFF
--- a/github-copilot/copilot-roman/src/main/java/copilot/roman/RomanToArabicConverter.java
+++ b/github-copilot/copilot-roman/src/main/java/copilot/roman/RomanToArabicConverter.java
@@ -7,6 +7,20 @@ public final class RomanToArabicConverter implements ToIntFunction<String> {
 
     @Override
     public int applyAsInt(String value) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        int result = 0;
+        for (int i = value.length(); i-- > 0; ) {
+            char symbol = value.charAt(i);
+            result += switch (symbol) {
+                case 'I' -> result >= 5 ? -1 : 1;
+                case 'V' -> 5;
+                case 'X' -> result >= 50 ? -10 : 10;
+                case 'L' -> 50;
+                case 'C' -> result >= 500 ? -100 : 100;
+                case 'D' -> 500;
+                case 'M' -> 1000;
+                default -> throw new IllegalArgumentException("Unexpected value: " + symbol);
+            };
+        }
+        return result;
     }
 }

--- a/github-copilot/copilot-roman/src/test/groovy/copilot/roman/RomanToArabicConverterTest.groovy
+++ b/github-copilot/copilot-roman/src/test/groovy/copilot/roman/RomanToArabicConverterTest.groovy
@@ -12,7 +12,6 @@ So that I can do arithmetic with them
 @See('https://en.wikipedia.org/wiki/Roman_numerals')
 class RomanToArabicConverterTest extends Specification {
 
-    @PendingFeature
     @Unroll('convert #roman to #arabic')
     def 'convert roman numeral to arabic number'() {
         given:


### PR DESCRIPTION
Replaced thrown UnsupportedOperationException in RomanToArabicConverter.java with a functional method that converts Roman numerals to Arabic numbers. The logic switches based on the passed Roman symbols and calculates the proper Arabic numbers based on the Roman numeral rules. Removed @PendingFeature annotation in the test file as this feature is no longer pending.