### PR TITLE
New module epam-ai-legal-age has been added to the project. 

### DIFF
--- a/epam-ai-dial/epam-ai-legal-age/pom.xml
+++ b/epam-ai-dial/epam-ai-legal-age/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>epam</groupId>
+        <artifactId>epam-ai-dial</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>epam-ai-legal-age</artifactId>
+
+    <name>
+        Legal Age Predicate
+    </name>
+    <description>
+        In this module, tests and implementation are created using EPAM AI Dial.
+    </description>
+    <url>
+        https://en.wikipedia.org/wiki/Legal_age
+    </url>
+
+</project>

--- a/epam-ai-dial/epam-ai-legal-age/src/main/java/epam/legalage/LegalAgePredicate.java
+++ b/epam-ai-dial/epam-ai-legal-age/src/main/java/epam/legalage/LegalAgePredicate.java
@@ -1,0 +1,44 @@
+package epam.legalage;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.function.Predicate;
+
+/**
+ * A predicate that checks if a user is over 18 years old based on their date of birth.
+ */
+public final class LegalAgePredicate implements Predicate<LocalDate> {
+
+    private static final int LEGAL_AGE = 18;
+    private final Clock clock;
+
+    /**
+     * Creates a LegalAgePredicate with the system default clock.
+     */
+    public LegalAgePredicate() {
+        this(Clock.systemDefaultZone());
+    }
+
+    /**
+     * Creates a LegalAgePredicate with the specified clock.
+     *
+     * @param clock the clock to use for calculating the current date
+     */
+    public LegalAgePredicate(Clock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Tests if the user with the given date of birth is over 18 years old.
+     *
+     * @param dateOfBirth the user's date of birth
+     * @return true if the user is over 18 years old, false otherwise
+     */
+    @Override
+    public boolean test(LocalDate dateOfBirth) {
+        var currentDate = LocalDate.now(clock);
+        var age = Period.between(dateOfBirth, currentDate).getYears();
+        return age >= LEGAL_AGE;
+    }
+}

--- a/epam-ai-dial/epam-ai-legal-age/src/test/java/epam/legalage/LegalAgePredicateAiTest.java
+++ b/epam-ai-dial/epam-ai-legal-age/src/test/java/epam/legalage/LegalAgePredicateAiTest.java
@@ -1,0 +1,41 @@
+package epam.legalage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("LegalAgePredicate tests")
+class LegalAgePredicateAiTest {
+
+    private static Stream<Arguments> legalAgePredicateTestCases() {
+        return Stream.of(
+                Arguments.of("User is exactly 18 years old", "2004-03-01", "2022-03-01", true),
+                Arguments.of("User is one day older than 18", "2004-02-28", "2022-03-01", true),
+                Arguments.of("User is one day younger than 18", "2004-03-02", "2022-03-01", false),
+                Arguments.of("User is exactly 19 years old", "2003-03-01", "2022-03-01", true),
+                Arguments.of("User is born today (edge case)", "2022-03-01", "2022-03-01", false)
+        );
+    }
+
+    @DisplayName("LegalAgePredicate test cases")
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("legalAgePredicateTestCases")
+    void legalAgePredicateTest(String description, String dateOfBirthStr, String currentDateStr, boolean expectedResult) {
+        var dateOfBirth = LocalDate.parse(dateOfBirthStr);
+        var currentDate = LocalDate.parse(currentDateStr);
+        var clock = Clock.fixed(currentDate.atStartOfDay(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+        var legalAgePredicate = new LegalAgePredicate(clock);
+
+        assertThat(legalAgePredicate.test(dateOfBirth))
+                .as("Check if user with date of birth %s is over 18 on %s", dateOfBirth, currentDate)
+                .isEqualTo(expectedResult);
+    }
+}

--- a/epam-ai-dial/pom.xml
+++ b/epam-ai-dial/pom.xml
@@ -16,7 +16,7 @@
         EPAM AI Dial
     </name>
     <description>
-        In this module, we have collected samples of unit tests created using EPAM artificial intelligence bot.
+        In this module, collected samples of unit tests created using EPAM AI Dial.
     </description>
     <url>
         https://chat.lab.epam.com/
@@ -30,6 +30,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <module>diffblue-cover</module>
         <module>epam-ai-dial</module>
         <module>github-copilot</module>
+        <module>epam-ai-dial/epam-ai-legal-age</module>
     </modules>
 
     <organization>


### PR DESCRIPTION
A new module epam-ai-legal-age has been added to the project. 

This module introduced a LegalAgePredicate class for checking whether a user is over 18 years old based on their date of birth. This logic is tested in LegalAgePredicateAiTest. These changes are essential for ensuring the software does not provide services to underage users, complying with international laws regarding the provision of certain digital services. Furthermore, the parent pom.xml and epam-ai-dial/pom.xml were updated to include new dependencies and modules required for these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an age verification feature to determine if a user is over 18 years old.

- **Tests**
  - Added new test cases to ensure the age verification feature works correctly under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->