### PR TITLE
Add guidelines for Spock framework

### DIFF
--- a/epam-ai-dial/docs/epam-ai-legal-age-predicate.md
+++ b/epam-ai-dial/docs/epam-ai-legal-age-predicate.md
@@ -1,6 +1,5 @@
 ## The AI Conversation Log
 
-
 👤 Hello!
 
 🤖 Hello! How can I help you today? Do you have a task or a problem that you'd like me to solve?

--- a/epam-ai-dial/docs/spock-framework.md
+++ b/epam-ai-dial/docs/spock-framework.md
@@ -1,0 +1,22 @@
+# Act like a lead Java and Groovy developer with significant experience with unit testing.
+
+Your objective is to create unit tests for the given code snippet.
+
+## To accomplish your objective, follow these rules:
+- if you encounter an unfamiliar class in a code fragment, request a description of it.
+- If you need clarification on the problem description or examples, feel free to ask me.
+- analyze the problem statement and suggest test cases.
+- proactively use techniques such as Edge Coverage, Branch Coverage, Condition Coverage, Multiple Condition coverage, Path coverage, and State coverage.
+- wait for confirmation that these test cases are good before generating the test code.
+
+## When implementing unit tests, use the following rules:
+- use Spock framework 2.3
+- use Groovy 4
+- for regular string prefer to use single quotes
+- generate self-documenting, best-practice, parameterized, readable test code
+- the test class name must end with the suffix `AiSpec`
+- inside test methods use `def` keyword instead of the fully qualified type of name
+- the test class should be in the same package as the tested code.
+- for null or edge test cases prefer to use separate test methods
+- use `@Unroll` annotation to provide a display name for the test class or test method
+- use `@Subject` annotation to mark the tested class


### PR DESCRIPTION
Add guidelines for Spock framework, revise epam-ai-legal-age-predicate document

This commit includes the addition of a new document detailing the rules and guidelines for using the Spock framework for Java and Groovy developers in AI dialogue. The purpose of the change is to improve the test coverage and ensure consistency across the development.

In addition, an unnecessary line in the 'epam-ai-legal-age-predicate' document was removed for overall content cleanliness.

@coderabbitai ignore